### PR TITLE
fix: partners url update mutation variable key

### DIFF
--- a/src/lib/shopifyCli.mjs
+++ b/src/lib/shopifyCli.mjs
@@ -76,8 +76,8 @@ export async function updateURLs(apiKey, url) {
 
 	const variables = {
 		apiKey,
-		appUrl: url + "/app",
-		redir: [
+		applicationUrl: url + "/app",
+		redirectUrlWhitelist: [
 			`${url}/api/auth`,
 			`${url}/api/auth/callback`,
 			`${url}/api/auth/offline`,


### PR DESCRIPTION
When cloning and running `yarn dev`, I get this error: 
```
Error: Variable $applicationUrl of type Url! was provided invalid value: {"response":{"errors":[{"message":"Variable $applicationUrl of type Url! was provided invalid value","locations":[{"line":2,"column":40}],"extensions":{"value":null,"problems":[{"path":[],"explanation":"Expected value to not be null"}]}},{"message":"Variable $redirectUrlWhitelist of type [Url]! was provided invalid value","locations":[{"line":2,"column":63}],"extensions":{"value":null,"problems":[{"path":[],"explanation":"Expected value to not be null"}]}}],"status":200,"headers":{}},"request":{"query":"\n  mutation appUpdate($apiKey: String!, $applicationUrl: Url!, $redirectUrlWhitelist: [Url]!) {\n    appUpdate(input: {apiKey: $apiKey, applicationUrl: $applicationUrl, redirectUrlWhitelist: $redirectUrlWhitelist}) {\n      userErrors {\n        message\n        field\n      }\n    }\n  }\n",
```

Here are the [mutation variable keys](https://github.com/Shopify/cli/blob/ede1be606205c62c911721857d09fc8097eb567a/packages/cli-kit/src/api/graphql/update_urls.ts#L14-L18) from the Shopify CLI Kit.