### PR TITLE
feat: Delete redis session on webhook uninstall

### DIFF
--- a/src/webhooks/index.ts
+++ b/src/webhooks/index.ts
@@ -1,10 +1,43 @@
-const webhooks = {
-    "APP_UNINSTALLED": {
-        path: '/api/webhooks',
-        webhookHandler: async (topic, shop, body) => {
-            console.log("App uninstalled")
-        }
-    }
-}
+const headers = {
+  Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
+};
 
-export default webhooks
+const webhooks = {
+  APP_UNINSTALLED: {
+    path: '/api/webhooks',
+    webhookHandler: async (topic, shop, body) => {
+      console.log('App uninstalled');
+
+      async function deleteKeys() {
+        const keysResponse = await fetch(
+          `${process.env.upstashRedisRestUrl}/keys/*`,
+          {
+            headers,
+          }
+        );
+        const keys = await keysResponse.json();
+
+        for (const key of keys.result) {
+          const valueResponse = await fetch(
+            `${process.env.upstashRedisRestUrl}/get/${key}`,
+            { method: 'GET', headers }
+          );
+          const value = await valueResponse.text();
+          console.log('Value: ', value);
+          if (value.includes(shop)) {
+            console.log(`Deleting key: ${key}`);
+
+            await fetch(`${process.env.upstashRedisRestUrl}/del/${key}`, {
+              method: 'GET',
+              headers,
+            });
+          }
+        }
+      }
+
+      deleteKeys();
+    },
+  },
+};
+
+export default webhooks;


### PR DESCRIPTION
I opened an issue a few days ago, #15, I was unable to install the app right after uninstalling it. 

So I fixed the issue by deleting Redis session key when the "`APP_UNINSTALLED`" webhook is called 