### PR TITLE
Revert "fix: partners url update mutation variable key"

### DIFF
--- a/src/lib/shopifyCli.mjs
+++ b/src/lib/shopifyCli.mjs
@@ -76,8 +76,8 @@ export async function updateURLs(apiKey, url) {
 
 	const variables = {
 		apiKey,
-		applicationUrl: url + "/app",
-		redirectUrlWhitelist: [
+		appUrl: url + "/app",
+		redir: [
 			`${url}/api/auth`,
 			`${url}/api/auth/callback`,
 			`${url}/api/auth/offline`,


### PR DESCRIPTION
This fix applies to a later version of the Shopify CLI than is listed in the package.json, which leads to the app erroring out until the variables are changed back. For reference, these are the variables used in shopify-cli 3.0.24:

```ts
declare const UpdateURLsQuery: string;
interface UpdateURLsQueryVariables {
    apiKey: string;
    appUrl: string;
    redir: string[];
}
```

[More details here](https://github.com/carstenlebek/shopify-non-embedded-app-template/pull/12#issuecomment-1525897410)